### PR TITLE
Adds footer text widget, also enables widgets for the theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -22,4 +22,19 @@ register_nav_menus( array(
 
 add_theme_support('custom-header');
 
+// Widgets
+function footer_widgets_init() {
+
+	register_sidebar( array(
+		'name'          => 'Footer text widget',
+		'id'            => 'footer_text',
+		'before_widget' => '<div>',
+		'after_widget'  => '</div>',
+		'before_title'  => '<h2>',
+		'after_title'   => '</h2>',
+	) );
+
+}
+add_action( 'widgets_init', 'footer_widgets_init' );
+
 ?>


### PR DESCRIPTION
This adds one widget to the functions.php file (each init functions initializes one to many widgets - we can either organize as all in one go, or have an init function for each group of widgets - whichever you prefer).

@sumeetgrewal @nanbul98 This should allow you to enter text into a text widget, then call it using the following php:
<?php dynamic_sidebar( 'widget_id' ); ?> in the footer.php file. I tried it out and it renders exactly as @nanbul98 has it on her current footer branch. Because it is a text widget, it wraps the text in a <p> tag, and you don't need to enter a title.

------

<img width="360" alt="screen shot 2018-11-05 at 3 49 52 pm" src="https://user-images.githubusercontent.com/16771580/48034013-75fd5e00-e112-11e8-80b6-6f9fbf837fa1.png">
